### PR TITLE
Add annotated Docker environment example

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,5 +1,12 @@
+# ----- Postgres -----
 POSTGRES_DB=odoo
 POSTGRES_USER=odoo
-POSTGRES_PASSWORD=odoo
+POSTGRES_PASSWORD=supersecret123   # change this if deploying to production
+
+# ----- Odoo -----
 ODOO_PORT=10069
+
+# ----- AI (optional) -----
+# If you want to enable AI suggestions, paste your real key here.
+# If left empty, the system will run in mock mode.
 OPENAI_API_KEY=


### PR DESCRIPTION
## Summary
- enhance docker/.env.example with comments and default values for Postgres, Odoo port, and optional AI key

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b158a838d88320991e54677d5e4ce2