### PR TITLE
Add dev initialization script

### DIFF
--- a/scripts/dev_init.sh
+++ b/scripts/dev_init.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")/../docker"
+
+echo ">>> Starting containers..."
+docker compose up -d
+
+echo ">>> Initializing Odoo database schema..."
+docker compose run --rm odoo \
+    odoo -d ${POSTGRES_DB:-odoo} -i base --stop-after-init \
+    --db_host=db --db_user=${POSTGRES_USER:-odoo} --db_password=${POSTGRES_PASSWORD:-odoo}
+
+echo ">>> Installing Waran-Hosp modules..."
+docker compose run --rm odoo \
+    odoo -d ${POSTGRES_DB:-odoo} \
+    -i waran_his_core,waran_his_lab,waran_his_pharmacy,waran_his_billing,waran_his_ai \
+    --stop-after-init \
+    --db_host=db --db_user=${POSTGRES_USER:-odoo} --db_password=${POSTGRES_PASSWORD:-odoo}
+
+echo ">>> Restarting Odoo..."
+docker compose restart odoo
+
+echo ">>> Done. Open http://localhost:${ODOO_PORT:-10069} (login: admin/admin)."


### PR DESCRIPTION
## Summary
- add dev init helper script to bootstrap Odoo containers and modules

## Testing
- `bash -n scripts/dev_init.sh`
- `./scripts/dev_init.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b177a16b00832094aefcaa8ff7adbe