### PR TITLE
fix: remove extra closing tag in demo data

### DIFF
--- a/addons/waran_his_core/data/demo.xml
+++ b/addons/waran_his_core/data/demo.xml
@@ -66,7 +66,6 @@
         <field name="plan">P</field>
         <field name="diagnosis_id" ref="diag_demo_1"/>
     </record>
-</odoo>
     <!-- Lab order and result -->
     <record id="lab_order_demo_1" model="waran.lab_order">
         <field name="patient_id" ref="patient_demo_1"/>


### PR DESCRIPTION
## Summary
- fix invalid `demo.xml` with extra closing tag causing module install crash

## Testing
- `xmllint --noout addons/waran_his_core/data/demo.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b1a2a9eb248320acce91646173136c