### PR TITLE
chore(admin): add HIS admin script for passwords and access

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Visit [http://localhost:10069](http://localhost:10069) and install modules as ab
 
 Set `OPENAI_API_KEY` in `docker/.env` to enable AI features.
 
+## Quick Admin Tasks
+
+- Install all modules: `scripts/his_admin.sh install-all`
+- Set a password: `scripts/his_admin.sh set-password admin admin123`
+- Grant department access: `scripts/his_admin.sh grant-access cfwaran@gmail.com`
+
 ## Modules
 - Core patient management and encounters
 - Laboratory orders and results

--- a/scripts/his_admin.sh
+++ b/scripts/his_admin.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Config from docker/.env with sensible defaults ---
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR/docker"
+
+POSTGRES_DB="${POSTGRES_DB:-${POSTGRES_DB:-odoo}}"
+POSTGRES_USER="${POSTGRES_USER:-${POSTGRES_USER:-odoo}}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-${POSTGRES_PASSWORD:-odoo}}"
+ODOO_DB="${POSTGRES_DB}"
+
+odoo_shell() {
+  docker compose run --rm odoo \
+    odoo -d "${ODOO_DB}" \
+    --db_host=db --db_user="${POSTGRES_USER}" --db_password="${POSTGRES_PASSWORD}" \
+    shell -c "$1"
+}
+
+install_modules() {
+  local mods="$1"
+  docker compose run --rm odoo \
+    odoo -d "${ODOO_DB}" -i "${mods}" --stop-after-init \
+    --db_host=db --db_user="${POSTGRES_USER}" --db_password="${POSTGRES_PASSWORD}"
+}
+
+set_password() {
+  local login="$1"
+  local password="$2"
+  odoo_shell "
+ u = env['res.users'].search([('login', '=', '${login}')], limit=1) or env['res.users'].search([('email', '=', '${login}')], limit=1)
+ assert u, 'User not found: ${login}'
+ u.write({'password': '${password}'})
+ print('Password set for', u.login)
+"
+}
+
+grant_his_access() {
+  local login="$1"
+  odoo_shell "
+ u = env['res.users'].search([('login', '=', '${login}')], limit=1) or env['res.users'].search([('email', '=', '${login}')], limit=1)
+ assert u, 'User not found: ${login}'
+ imd = env['ir.model.data']
+ xmlids = [
+     'waran_his_core.group_waran_admin',
+     'waran_his_core.group_waran_registration',
+     'waran_his_core.group_waran_clinical_doctor',
+     'waran_his_core.group_waran_clinical_nurse',
+     'waran_his_lab.group_waran_lab',
+     'waran_his_pharmacy.group_waran_pharmacy',
+     'waran_his_billing.group_waran_billing',
+ ]
+ groups = [imd.xmlid_to_object(x) for x in xmlids if imd.xmlid_to_object(x)]
+ u.write({'groups_id': [(6, 0, [g.id for g in groups if g])]})
+ print('Granted HIS groups to', u.login, [g.xml_id for g in groups if g])
+"
+}
+
+usage() {
+  cat <<USAGE
+Usage:
+  scripts/his_admin.sh install-all
+      -> installs all HIS modules (core, lab, pharmacy, billing, ai) and restarts Odoo
+
+  scripts/his_admin.sh set-password <login_or_email> <new_password>
+      -> sets password for the given user
+
+  scripts/his_admin.sh grant-access <login_or_email>
+      -> grants all HIS department groups to that user
+
+Examples:
+  scripts/his_admin.sh install-all
+  scripts/his_admin.sh set-password admin admin123
+  scripts/his_admin.sh grant-access cfwaran@gmail.com
+USAGE
+}
+
+case "${1:-}" in
+  install-all)
+    install_modules "waran_his_core,waran_his_lab,waran_his_pharmacy,waran_his_billing,waran_his_ai"
+    docker compose restart odoo
+    ;;
+  set-password)
+    [[ $# -eq 3 ]] || { usage; exit 1; }
+    set_password "$2" "$3"
+    ;;
+  grant-access)
+    [[ $# -eq 2 ]] || { usage; exit 1; }
+    grant_his_access "$2"
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add helper `his_admin.sh` script for installing modules, setting user passwords and granting HIS groups
- document quick admin tasks in README
- ensure shell scripts use LF line endings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2758e6a388320afb179e333ae841c