### PR TITLE
fix: add `mail` dependency to HIS addons (lab/billing/pharmacy) to satisfy chatter mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Set `OPENAI_API_KEY` in `docker/.env` to enable AI features.
 - Grant department access: `scripts/his_admin.sh grant-access cfwaran@gmail.com`
 - Upgrade all modules: `scripts/his_admin.sh upgrade-all`
 
+## Upgrade
+
+```bash
+cd /opt/Waran-hosp/docker
+docker compose exec odoo ./odoo-bin -d waranhosp -u waran_his_lab,waran_his_billing,waran_his_pharmacy
+```
+
 ## Modules
 - Core patient management and encounters
 - Laboratory orders and results

--- a/addons/waran_his_billing/__manifest__.py
+++ b/addons/waran_his_billing/__manifest__.py
@@ -3,7 +3,7 @@
     "version": "17.0.1.0.0",
     "license": "LGPL-3",
     "category": "Healthcare",
-    "depends": ["waran_his_core", "account"],
+    "depends": ["base", "mail", "waran_his_core", "account"],
     "data": [
         "security/ir.model.access.csv",
         "views/menu.xml",

--- a/addons/waran_his_lab/models/lab_result.py
+++ b/addons/waran_his_lab/models/lab_result.py
@@ -3,7 +3,7 @@ from odoo import api, fields, models
 class LabResult(models.Model):
     _name = 'waran.lab_result'
     _description = 'Lab Result'
-    _inherit = ['mail.thread']
+    _inherit = ['mail.thread', 'mail.activity.mixin']
 
     lab_order_id = fields.Many2one('waran.lab_order', required=True)
     result_value = fields.Char()

--- a/addons/waran_his_pharmacy/__manifest__.py
+++ b/addons/waran_his_pharmacy/__manifest__.py
@@ -3,7 +3,7 @@
     "version": "17.0.1.0.0",
     "license": "LGPL-3",
     "category": "Healthcare",
-    "depends": ["waran_his_core", "stock"],
+    "depends": ["base", "mail", "waran_his_core", "stock"],
     "data": [
         "security/ir.model.access.csv",
         "views/menu.xml",


### PR DESCRIPTION
## Summary
- ensure depends include `mail` for models inheriting mail.thread / mail.activity.mixin
- add README upgrade snippet

## Testing
- `python -m py_compile addons/waran_his_billing/__manifest__.py addons/waran_his_pharmacy/__manifest__.py addons/waran_his_lab/models/lab_result.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2d9d425888320a947c7815b5a66db