### PR TITLE
ops: add admin helpers and utf8

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ Set `OPENAI_API_KEY` in `docker/.env` to enable AI features.
 - Grant department access: `scripts/his_admin.sh grant-access cfwaran@gmail.com`
 - Upgrade all modules: `scripts/his_admin.sh upgrade-all`
 
+### Operations
+```bash
+# install all departments
+scripts/his_admin.sh install-all
+
+# upgrade just Lab & Pharmacy
+scripts/his_admin.sh upgrade waran_his_lab waran_his_pharmacy
+
+# resolve queued modules
+scripts/his_admin.sh resolve-queued
+
+# follow logs (UTF-8 fixed in docker-compose)
+scripts/his_admin.sh logs
+```
+
 ## Upgrade
 
 ```bash

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -22,6 +22,8 @@ services:
       - PASSWORD=${POSTGRES_PASSWORD}
       - DB_NAME=${POSTGRES_DB}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - LANG=C.UTF-8
+      - LC_ALL=C.UTF-8
     volumes:
       - odoo-data:/var/lib/odoo
       - ../addons:/mnt/extra-addons

--- a/scripts/his_admin.sh
+++ b/scripts/his_admin.sh
@@ -1,54 +1,46 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
-# --- Config from docker/.env with sensible defaults ---
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-ENV_FILE="$ROOT_DIR/docker/.env"
-if [ -f "$ENV_FILE" ]; then set -a; . "$ENV_FILE"; set +a; fi
-: "${ODOO_DB:=${POSTGRES_DB:-odoo}}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DOCKER_DIR="$ROOT/docker"
 
-cd "$ROOT_DIR/docker"
-POSTGRES_USER="${POSTGRES_USER:-odoo}"
-POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-odoo}"
+# Load .env if present
+if [ -f "$DOCKER_DIR/.env" ]; then
+  set -a; source "$DOCKER_DIR/.env"; set +a
+fi
+DB="${POSTGRES_DB:-waranhosp}"
+DB_USER="${POSTGRES_USER:-odoo}"
+DB_PASS="${POSTGRES_PASSWORD:-odoo}"
+
+dc() { (cd "$DOCKER_DIR" && docker compose "$@"); }
+
+odoo_cmd() {
+  dc exec odoo odoo -d "$DB" "$@" \
+    --db_host=db --db_user="$DB_USER" --db_password="$DB_PASS"
+}
 
 odoo_shell() {
   local py="$1"
-  docker compose run --rm odoo bash -lc "
-odoo shell -d "${ODOO_DB}" \
-  --db_host=db --db_user="${POSTGRES_USER}" --db_password="${POSTGRES_PASSWORD}" <<'PY'
+  dc run --rm odoo bash -lc "
+odoo shell -d \"$DB\" \\
+  --db_host=db --db_user=\"$DB_USER\" --db_password=\"$DB_PASS\" <<'PY'
 ${py}
 PY
 "
 }
 
-install_modules() {
-  local mods="$1"
-  docker compose run --rm odoo \
-    odoo -d "${ODOO_DB}" -i "${mods}" --stop-after-init \
-    --db_host=db --db_user="${POSTGRES_USER}" --db_password="${POSTGRES_PASSWORD}"
-}
-
-upgrade_all() {
-  docker compose run --rm odoo \
-    odoo -d "${ODOO_DB}" -u all --stop-after-init \
-    --db_host=db --db_user="${POSTGRES_USER}" --db_password="${POSTGRES_PASSWORD}"
-}
-
 set_password() {
-  local login="$1"
-  local password="$2"
-  odoo_shell "
-u = env['res.users'].search([('login', '=', '${login}')], limit=1) or env['res.users'].search([('email', '=', '${login}')], limit=1)
+  local login="$1"; local password="$2"
+  odoo_shell "u = env['res.users'].search([('login', '=', '${login}')], limit=1) or env['res.users'].search([('email', '=', '${login}')], limit=1)
 assert u, 'User not found: ${login}'
 u.write({'password': '${password}'})
 print('Password set for', u.login)
 "
 }
 
-grant_his_access() {
+grant_access() {
   local login="$1"
-  odoo_shell "
-u = env['res.users'].search([('login', '=', '${login}')], limit=1) or env['res.users'].search([('email', '=', '${login}')], limit=1)
+  odoo_shell "u = env['res.users'].search([('login', '=', '${login}')], limit=1) or env['res.users'].search([('email', '=', '${login}')], limit=1)
 assert u, 'User not found: ${login}'
 xmlids = [
     'waran_his_core.group_waran_admin',
@@ -74,7 +66,7 @@ print('Granted HIS groups to', u.login, groups)
 }
 
 usage() {
-  cat <<USAGE
+  cat <<'EOF'
 Usage:
   scripts/his_admin.sh install-all
       -> installs all HIS modules (core, lab, pharmacy, billing, ai) and restarts Odoo
@@ -88,32 +80,82 @@ Usage:
   scripts/his_admin.sh upgrade-all
       -> upgrades all installed modules and restarts Odoo
 
+  scripts/his_admin.sh upgrade <module1> [module2 ...]
+      -> upgrades only the listed modules (no restart)
+
+  scripts/his_admin.sh resolve-queued
+      -> runs '-u all --stop-after-init' once to clear queued installs
+
+  scripts/his_admin.sh odoo "<raw args>"
+      -> pass raw args to 'odoo' inside the container (advanced)
+
+  scripts/his_admin.sh logs
+      -> follow Odoo logs
+
+  scripts/his_admin.sh health
+      -> wait until Odoo HTTP endpoint responds
 Examples:
   scripts/his_admin.sh install-all
   scripts/his_admin.sh set-password admin admin123
   scripts/his_admin.sh grant-access cfwaran@gmail.com
   scripts/his_admin.sh upgrade-all
-USAGE
+  scripts/his_admin.sh upgrade waran_his_lab waran_his_pharmacy
+  scripts/his_admin.sh resolve-queued
+  scripts/his_admin.sh odoo "-u all --stop-after-init"
+  scripts/his_admin.sh logs
+EOF
 }
 
-case "${1:-}" in
+cmd="${1:-}"; shift || true
+case "${cmd}" in
   install-all)
-    install_modules "waran_his_core,waran_his_lab,waran_his_pharmacy,waran_his_billing,waran_his_ai"
-    docker compose restart odoo
+    dc up -d
+    odoo_cmd -i waran_his_core,waran_his_lab,waran_his_pharmacy,waran_his_billing,waran_his_ai --stop-after-init
+    dc restart odoo
     ;;
   upgrade-all)
-    upgrade_all
-    docker compose restart odoo
+    odoo_cmd -u all --stop-after-init
+    dc restart odoo
+    ;;
+  upgrade)
+    [ "$#" -ge 1 ] || { echo "Usage: scripts/his_admin.sh upgrade <module1> [module2 ...]"; exit 1; }
+    IFS=, modules="$*"
+    modules="${modules// /,}"
+    odoo_cmd -u "${modules}" --stop-after-init
+    ;;
+  resolve-queued)
+    odoo_cmd -u all --stop-after-init
+    ;;
+  odoo)
+    [ "$#" -ge 1 ] || { echo 'Usage: scripts/his_admin.sh odoo "<raw args>"'; exit 1; }
+    odoo_cmd "$@"
+    ;;
+  logs)
+    dc logs -f odoo
+    ;;
+  health)
+    # wait up to ~120s
+    for i in $(seq 1 60); do
+      if curl -fsS "http://127.0.0.1:${ODOO_PORT:-8069}/web/login" >/dev/null; then
+        echo "Odoo is responding"; exit 0
+      fi
+      sleep 2
+    done
+    echo "Odoo did not respond in time"; exit 1
     ;;
   set-password)
-    [[ $# -eq 3 ]] || { usage; exit 1; }
-    set_password "$2" "$3"
+    [ "$#" -eq 2 ] || { echo 'Usage: scripts/his_admin.sh set-password <login_or_email> <new_password>'; exit 1; }
+    set_password "$1" "$2"
     ;;
   grant-access)
-    [[ $# -eq 2 ]] || { usage; exit 1; }
-    grant_his_access "$2"
+    [ "$#" -eq 1 ] || { echo 'Usage: scripts/his_admin.sh grant-access <login_or_email>'; exit 1; }
+    grant_access "$1"
+    ;;
+  ""|-h|--help|help)
+    usage
     ;;
   *)
+    echo "Unknown command: $cmd"
     usage
     exit 1
     ;;


### PR DESCRIPTION
## Summary
- force UTF-8 locale in odoo container
- extend his_admin helper with more admin subcommands
- document common operations

## Testing
- `bash -n scripts/his_admin.sh`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e6ae4cd08320aa4cc4b35aacda80