### PR TITLE
Add HIS menu/action utility script and helper

### DIFF
--- a/scripts/ensure_menus.py
+++ b/scripts/ensure_menus.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Ensure HIS models have actions and menus.
+
+Reads database credentials from environment variables or a `.env` file and
+connects to the Odoo registry. For each model whose technical name starts with
+`waran.` it ensures there is an `ir.actions.act_window` (tree/form) and a
+corresponding `ir.ui.menu` under the root menu
+`waran_his_core.waran_menu_root`.
+"""
+
+import os
+from pathlib import Path
+
+import odoo
+from odoo import api
+from odoo.modules.registry import Registry
+from odoo.tools import config
+
+
+def load_env() -> None:
+    """Load environment variables from `docker/.env` if present."""
+    try:
+        root = Path(__file__).resolve().parents[1]
+    except Exception:  # when running from stdin
+        root = Path.cwd()
+    env_file = root / "docker" / ".env"
+    if env_file.exists():
+        for line in env_file.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            os.environ.setdefault(k.strip(), v.strip())
+
+
+def ensure_menus() -> None:
+    load_env()
+
+    db = os.getenv("POSTGRES_DB", "waranhosp")
+    user = os.getenv("POSTGRES_USER", "odoo")
+    password = os.getenv("POSTGRES_PASSWORD", "odoo")
+    host = os.getenv("PGHOST", "db")
+    port = os.getenv("PGPORT", "5432")
+    addons_path = os.getenv(
+        "ODOO_ADDONS_PATH",
+        "/usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons",
+    )
+
+    config["db_host"] = host
+    config["db_port"] = port
+    config["db_user"] = user
+    config["db_password"] = password
+    config["addons_path"] = addons_path
+
+    registry = Registry.new(db)
+    with registry.cursor() as cr:
+        env = api.Environment(cr, odoo.SUPERUSER_ID, {})
+        try:
+            root_menu = env.ref("waran_his_core.waran_menu_root")
+        except ValueError as exc:
+            raise SystemExit("Root menu waran_his_core.waran_menu_root not found") from exc
+
+        seq = 10
+        for model in sorted(m for m in registry.models if m.startswith("waran.")):
+            desc = env[model]._description or model
+            action = env["ir.actions.act_window"].search(
+                [("res_model", "=", model), ("view_mode", "=", "tree,form")],
+                limit=1,
+            )
+            if not action:
+                action = env["ir.actions.act_window"].create(
+                    {
+                        "name": desc,
+                        "res_model": model,
+                        "view_mode": "tree,form",
+                    }
+                )
+            menu = env["ir.ui.menu"].search(
+                [
+                    ("parent_id", "=", root_menu.id),
+                    ("action", "=", f"ir.actions.act_window,{action.id}"),
+                ],
+                limit=1,
+            )
+            if not menu:
+                env["ir.ui.menu"].create(
+                    {
+                        "name": desc,
+                        "parent_id": root_menu.id,
+                        "action": f"ir.actions.act_window,{action.id}",
+                        "sequence": seq,
+                    }
+                )
+                seq += 10
+    print("✅ menus/actions ensured")
+
+
+if __name__ == "__main__":
+    ensure_menus()

--- a/scripts/his_admin.sh
+++ b/scripts/his_admin.sh
@@ -86,6 +86,9 @@ Usage:
   scripts/his_admin.sh resolve-queued
       -> runs '-u all --stop-after-init' once to clear queued installs
 
+  scripts/his_admin.sh ensure-menus
+      -> ensures HIS models have actions and menus
+
   scripts/his_admin.sh odoo "<raw args>"
       -> pass raw args to 'odoo' inside the container (advanced)
 
@@ -125,6 +128,15 @@ case "${cmd}" in
     ;;
   resolve-queued)
     odoo_cmd -u all --stop-after-init
+    ;;
+  ensure-menus)
+    cat "$ROOT/scripts/ensure_menus.py" | \
+      dc run --rm -T \
+        -e POSTGRES_DB="$DB" \
+        -e POSTGRES_USER="$DB_USER" \
+        -e POSTGRES_PASSWORD="$DB_PASS" \
+        -e PGHOST=db -e PGPORT=5432 \
+        odoo python -
     ;;
   odoo)
     [ "$#" -ge 1 ] || { echo 'Usage: scripts/his_admin.sh odoo "<raw args>"'; exit 1; }


### PR DESCRIPTION
## Summary
- add `scripts/ensure_menus.py` to create missing `ir.actions.act_window` and `ir.ui.menu` entries for all `waran.*` models
- extend `scripts/his_admin.sh` with `ensure-menus` command that runs the utility inside the Odoo container

## Testing
- `python -m py_compile scripts/ensure_menus.py`
- `bash scripts/his_admin.sh ensure-menus` *(fails: `docker: command not found`)*
- `python scripts/ensure_menus.py` *(fails: `ModuleNotFoundError: No module named 'odoo'`)*

------
https://chatgpt.com/codex/tasks/task_e_68b407f7315483208cd339d58f9d2e3e