### PR TITLE
feat: add db fix and menu helper

### DIFF
--- a/scripts/db_fix_and_menus.sh
+++ b/scripts/db_fix_and_menus.sh
@@ -1,20 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-GREEN="\033[32m"
-RESET="\033[0m"
-
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DOCKER_DIR="$ROOT/docker"
 ENV_FILE="$DOCKER_DIR/.env"
 
 # Ensure docker compose is available
 if ! command -v docker >/dev/null 2>&1; then
-  echo "docker is required" >&2
+  echo "Error: docker is required" >&2
   exit 1
 fi
 if ! docker compose version >/dev/null 2>&1; then
-  echo "docker compose is required" >&2
+  echo "Error: docker compose (v2) is required" >&2
   exit 1
 fi
 
@@ -22,49 +19,71 @@ fi
 if [ -f "$ENV_FILE" ]; then
   set -a
   # shellcheck disable=SC1090
-  source "$ENV_FILE"
+  . "$ENV_FILE"
   set +a
 else
   echo "Warning: $ENV_FILE not found, using defaults" >&2
 fi
 
-DB="${POSTGRES_DB:-waranhosp}"
-USER="${POSTGRES_USER:-odoo}"
-PASS="${POSTGRES_PASSWORD:-odoo}"
+POSTGRES_DB="${POSTGRES_DB:-waranhosp}"
+POSTGRES_USER="${POSTGRES_USER:-odoo}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-}"
 
-dc() {
-  (cd "$DOCKER_DIR" && docker compose "$@")
+if [ -z "$POSTGRES_PASSWORD" ]; then
+  echo "Error: POSTGRES_PASSWORD not set in $ENV_FILE" >&2
+  exit 1
+fi
+
+dc() { (cd "$DOCKER_DIR" && docker compose "$@"); }
+
+hint() {
+  echo "Is the stack running? Try: cd docker && docker compose up -d" >&2
 }
 
-# 1. Reset password
-printf 'Resetting Postgres password for %s...\n' "$USER"
-dc exec db psql -U postgres -c "ALTER USER $USER WITH PASSWORD '$PASS';" >/dev/null
-printf "%b✅ reset password for %s%b\n" "$GREEN" "$USER" "$RESET"
+# Reset DB role/password
+SQL="DO \$\$ BEGIN
+          IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${POSTGRES_USER}') THEN
+            CREATE ROLE ${POSTGRES_USER} LOGIN SUPERUSER CREATEDB CREATEROLE REPLICATION BYPASSRLS PASSWORD '${POSTGRES_PASSWORD}';
+          ELSE
+            ALTER USER ${POSTGRES_USER} WITH SUPERUSER CREATEDB CREATEROLE REPLICATION BYPASSRLS PASSWORD '${POSTGRES_PASSWORD}';
+          END IF;
+        END \$\$;"
 
-# 2. Verify connectivity from odoo container
-printf 'Testing database connectivity from odoo container...\n'
-if ! dc exec odoo bash -lc "PGPASSWORD='$PASS' psql -h db -U '$USER' -d '$DB' -c 'SELECT 1;' >/dev/null"; then
-  echo "Error: database connection test failed" >&2
+if ! dc exec -T -u postgres db psql -v ON_ERROR_STOP=1 -U postgres -d postgres -c "$SQL"; then
+  hint
   exit 1
 fi
-printf "%b✅ DB connectivity OK%b\n" "$GREEN" "$RESET"
+echo "✅ reset/created role ${POSTGRES_USER}"
 
-# 3. Ensure menus/actions
+# Verify connectivity from odoo container
+if ! dc exec -T odoo bash -lc "PGPASSWORD='${POSTGRES_PASSWORD}' psql -h db -p 5432 -U '${POSTGRES_USER}' -d '${POSTGRES_DB}' -c 'SELECT 1;' >/dev/null"; then
+  echo "Error: DB connectivity test failed" >&2
+  hint
+  exit 1
+fi
+echo "✅ DB connectivity OK (odoo -> db)"
+
+# Ensure menus/actions
 ENSURE_SCRIPT="$ROOT/scripts/ensure_menus.py"
-if [ ! -f "$ENSURE_SCRIPT" ]; then
-  echo "Error: $ENSURE_SCRIPT not found" >&2
-  exit 1
+if [ -f "$ENSURE_SCRIPT" ]; then
+  if ! dc cp "$ENSURE_SCRIPT" odoo:/opt/ensure_menus.py; then
+    hint
+    exit 1
+  fi
+  if ! dc exec -T \
+      -e POSTGRES_DB="${POSTGRES_DB}" \
+      -e PGHOST=db -e PGPORT=5432 \
+      -e PGUSER="${POSTGRES_USER}" \
+      -e PGPASSWORD="${POSTGRES_PASSWORD}" \
+      odoo python3 /opt/ensure_menus.py; then
+    hint
+    exit 1
+  fi
+  echo "✅ menus/actions ensured"
+else
+  echo "⚠️ $ENSURE_SCRIPT not found; skipping menu/action fixes" >&2
 fi
 
-printf 'Copying ensure_menus.py into odoo container...\n'
-dc cp "$ENSURE_SCRIPT" odoo:/opt/ensure_menus.py
-
-printf 'Running ensure_menus.py...\n'
-dc exec \
-  -e POSTGRES_DB="$DB" \
-  -e PGHOST=db \
-  -e PGPORT=5432 \
-  -e PGUSER="$USER" \
-  -e PGPASSWORD="$PASS" \
-  odoo python3 /opt/ensure_menus.py >/dev/null
-printf "%b✅ menus/actions ensured%b\n" "$GREEN" "$RESET"
+echo "Next steps:"
+echo " - Hard refresh the browser and check Settings → Technical → Actions → Window Actions (search 'waran')."
+echo " - If menus are still hidden, go to Settings → Technical → User Interface → Menu Items and clear the Groups field or set to Internal User."

--- a/scripts/his_admin.sh
+++ b/scripts/his_admin.sh
@@ -90,7 +90,10 @@ Usage:
       -> ensures HIS models have actions and menus
 
   scripts/his_admin.sh db-fix-and-menus
-      -> resets DB password, verifies connectivity and ensures menus
+      -> resets DB password (inside db container), verifies connectivity (from odoo), and ensures menus/actions
+
+  scripts/his_admin.sh fix-db-and-menus
+      -> alias of db-fix-and-menus
 
   scripts/his_admin.sh odoo "<raw args>"
       -> pass raw args to 'odoo' inside the container (advanced)
@@ -142,7 +145,7 @@ case "${cmd}" in
         -e PGHOST=db -e PGPORT=5432 \
         odoo python -
     ;;
-  db-fix-and-menus)
+  db-fix-and-menus|fix-db-and-menus)
     "$ROOT/scripts/db_fix_and_menus.sh"
     ;;
   odoo)


### PR DESCRIPTION
## Summary
- reset/create the database role inside the Postgres container and ensure menus
- add `db-fix-and-menus` admin command with `fix-db-and-menus` alias

## Testing
- `bash -n scripts/db_fix_and_menus.sh`
- `bash -n scripts/his_admin.sh`
- `./scripts/his_admin.sh db-fix-and-menus` *(fails: Error: docker is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b4211f314c8320a2d1555cc745f742